### PR TITLE
WG won't use a W3C wiki

### DIFF
--- a/index.html
+++ b/index.html
@@ -105,7 +105,6 @@
           <ul class="theme">
             <li><a href="//www.w3.org/2015/10/webplatform-charter.html">Charter</a></li>
             <li><a href="//www.w3.org/2000/09/dbwg/details?group=83482&amp;public=1&amp;gs=1&amp;">Group Participants</a></li>
-            <li><a href="//www.w3.org/2008/webapps/wiki/">Wiki</a></li>
 <!--            <li><a href="/2008/webapps/track/">Known WebApps Issues</a></li> old link, not used anymore,kept here for history -->
             <li><a href="//www.w3.org/2004/01/pp-impl/83482/status">Royalty-free Patent Policy</a></li>
             <li><a href="//www.w3.org/2004/01/pp-impl/83482/join">Join this group (W3C account required)</a></li>


### PR DESCRIPTION
At least at the start, the group won't use a wiki, just Github.
