### PR TITLE
Use Apiary to show updated info on home page

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
 
-<html lang="en">
+<html lang="en" data-apiary-key="8jojid8y7vokww04osk04k8o4ocs000" data-apiary-group="83482" data-apiary-mode="production">
 <head>
 <meta charset="utf-8">
-<title>W3C Web Platform Working Group</title>
+<title data-apiary="name">W3C Web Platform Working Group</title>
 <meta name="mobile-web-app-capable" content="yes">
-<meta name="viewport" content="width=device-width, initial-scale=1, initial-scale = 1.0, 
+<meta name="viewport" content="width=device-width, initial-scale=1, initial-scale = 1.0,
 shrink-to-fit=no">
 <link rel="stylesheet" href="css/main.css">
 <script async type="text/javascript" src="js/newsfeed.js"> </script>
@@ -25,20 +25,17 @@ shrink-to-fit=no">
 
 <main>
 <section id="content">
-<h1>About the Web Platform Working Group</h1>
+<h1>About the <span data-apiary="name">Web Platform Working Group</span></h1>
 
-<p>Information about the Web Platform Working Group, known as the WebPlat WG.
+<p>Information about the <span data-apiary="name">Web Platform Working Group</span>, known as the WebPlat WG.
 
 <section id="mission">
 <h2>What we do</h2>
 
-<p>We develop the HTML and DOM (Document Object Model) standards, as well as new specifications 
-including Service Workers and Custom Elements. We also work on lots of API (Application Programming 
-Interface) specifications, including the Push API, Screen Orientation API, Pointer Lock API, and 
-IndexedDB API.</p>
+<p data-apiary="description">[Loading…]</p>
 
-<p>We produce standards that are protected by the <a 
-href="https://www.w3.org/2004/01/pp-impl/83482/status">W3C Royalty-free Patent Policy</a>. This 
+<p>We produce standards that are protected by the <a
+href="https://www.w3.org/2004/01/pp-impl/83482/status">W3C Royalty-free Patent Policy</a>. This
 ensures that W3C standards will remain free for everyone to use, now and in the future.</p>
 
 <p>Our <a href="https://www.w3.org/WebPlatform/WG/PubStatus">Publication Status page</a> and <a 
@@ -46,14 +43,14 @@ href="https://labs.w3.org/unitas/?g=83482">Unitas dashboard</a> have information
 WebPlat WG specifications, including links to the relevant GitHub repositories.</p>
 </section>
 
+<section id="who">
 <h2>Who we are</h2>
 
-<p>The WebPlat WG co-chairs are <a href="mailto:adrianba@microsoft.com">Adrian Bateman 
-(Microsoft)</a>, <a href="mailto:lwatson@paciellogroup.com">Léonie Watson (The Paciello Group)</a>, 
-and <a href="mailto:chaals@yandex-team.ru">Chaals McCathie Nevile (Yandex)</a>.</p>
+<p>The WebPlat WG co-chairs are <a href="mailto:chaals@yandex-team.ru">Chaals McCathie Nevile (Yandex)</a>
+and <a href="mailto:lwatson@paciellogroup.com">Léonie Watson (The Paciello Group)</a>.</p>
 
-The W3C team contacts for the WebPlat WG are <a href="mailto:xiaoqian@w3.org">Xiaoqian Wu</a> and <a 
-href="mailto:ylafon@w3.org">Yves Lafon</a>.</p>
+<p>The W3C team contacts for the WebPlat WG are <a href="mailto:ylafon@w3.org">Yves Lafon</a>,
+<a href="mailto:xfq@w3.org">Fuqiao Xue</a> and <a href="mailto:xiaoqian@w3.org">Xiaoqian Wu</a>.</p>
 
 <p>We have more than 150 <a 
 href="https://www.w3.org/2000/09/dbwg/details?group=83482&public=1&gs=1&">participants</a> from 
@@ -70,32 +67,31 @@ lists</a>.</p>
 <li><a href="https://www.w3.org/participate/">Participate in W3C</a></li>
 <li><a href="https://www.w3.org/2004/01/pp-impl/83482/join">Join WebPlat WG (needs a W3C account)</a></li>
 <li><a href="https://www.w3.org/Consortium/cepc/">W3C code of conduct</a></li>
-<li><a href="https://github.com/w3c/WebPlatformWG/blob/gh-pages/WorkMode.md">WebPlat WG work 
+<li><a href="https://github.com/w3c/WebPlatformWG/blob/gh-pages/WorkMode.md">WebPlat WG work
 mode</a></li>
 </ul>
 
 <h3 id="emails">Our email lists</h3>
 
-<p>We use the <a href="https://lists.w3.org/Archives/Public/public-webapps/">public-webapps 
+<p>We use the <a href="https://lists.w3.org/Archives/Public/public-webapps/">public-webapps
 email</a> for general discussions. We also have email lists for discussing specific topics:</p>
 <ul>
 <li><a href="https://lists.w3.org/Archives/Public/public-html/">HTML: public-html</a></li>
 <li><a href="https://lists.w3.org/Archives/Public/www-dom/">DOM: www-dom</a></li>
-<li><a href="https://lists.w3.org/Archives/Public/public-script-coord/">WebIDL and ECMA TC39 
+<li><a href="https://lists.w3.org/Archives/Public/public-script-coord/">WebIDL and ECMA TC39
 liaisons: public-script-coord</a></li>
-<li><a href="(https://lists.w3.org/Archives/Public/public-editing-tf/">Editing Task Force: 
+<li><a href="(https://lists.w3.org/Archives/Public/public-editing-tf/">Editing Task Force:
 public-editing-tf</a></li>
 </ul>
 
 <h3>Our meetings</h3>
 
-<p>We post agendas and minutes for all <a 
+<p>We post agendas and minutes for all <a
 href="https://github.com/w3c/WebPlatformWG/blob/gh-pages/Meetings.md">WebPlat WG meetings</a>.</p>
 
 <h2>Our charter</h2>
 
-<p>The <a href="https://www.w3.org/2017/08/webplatform-charter.html">WebPlat WG charter</a> runs 
-until 30 September 2018.</p>
+<p>Chartered from <span data-apiary="start-date"></span> to <span data-apiary="end-date"></span>.</p>
 
 <section id="articles">
 <article class="line">
@@ -110,9 +106,9 @@ until 30 September 2018. Intersection observers and static range were added to i
 
 <p>Minutes from the Service Workers meeting in Tokyo, on 3 and 4 April 2017.</p>
 <ul>
-<li><a href="https://www.w3.org/2017/04/03-serviceworkers-minutes.html" aria-label="Service Workers 
+<li><a href="https://www.w3.org/2017/04/03-serviceworkers-minutes.html" aria-label="Service Workers
 minutes day 1">Day 1 minutes</a></li>
-<li><a href="https://www.w3.org/2017/04/04-serviceworkers-minutes.html" aria-label="Service Workers 
+<li><a href="https://www.w3.org/2017/04/04-serviceworkers-minutes.html" aria-label="Service Workers
 minutes day 2">Day 2 minutes</a></li>
 </ul>
 </article>
@@ -122,11 +118,11 @@ minutes day 2">Day 2 minutes</a></li>
 
 <p>Minutes from the HTML meeting in Amsterdam, on 28 to 30 March 2017.</p>
 <ul>
-<li><a href="https://www.w3.org/2017/03/28-html-minutes.html" aria-label="HTML minutes day 1">Day 1 
+<li><a href="https://www.w3.org/2017/03/28-html-minutes.html" aria-label="HTML minutes day 1">Day 1
 minutes</a></li>
-<li><a href="https://www.w3.org/2017/03/29-html-minutes.html" aria-label="HTML minutes day 2">Day 2 
+<li><a href="https://www.w3.org/2017/03/29-html-minutes.html" aria-label="HTML minutes day 2">Day 2
 minutes</a></li>
-<li><a href="https://www.w3.org/2017/03/30-html-minutes.html" aria-label="HTML minutes day 3">Day 3 
+<li><a href="https://www.w3.org/2017/03/30-html-minutes.html" aria-label="HTML minutes day 3">Day 3
 minutes</a></li>
 </ul>
 </article>
@@ -139,11 +135,12 @@ minutes</a></li>
 <address>
 <a href="https://github.com/w3c/WebPlatformWG/">We are on GitHub</a></address>
 <p id="copyright">
-<a href="https://www.w3.org/">W3C</a> - <a 
-href="https://www.w3.org/Consortium/Legal/privacy-statement">Privacy</a> - <a 
+<a href="https://www.w3.org/">W3C</a> - <a
+href="https://www.w3.org/Consortium/Legal/privacy-statement">Privacy</a> - <a
 href='http://www.w3.org/Consortium/Legal/ipr-notice'>Terms</a>
 </p>
 </footer>
 
+<script src="//w3c.github.io/apiary/apiary.js"></script>
 </body>
 </html>


### PR DESCRIPTION
Inject dynamically, from the public API:

* Name of the group in several places (kind of trivial, yes)
* Updated description of the group
* Total period chartered, up to end of last charter

While at it, fix this too (static content):

* Info about team contacts and chairs was not up to date; fixed (Apiary can populate that too, but currently the hyperlinks it creates lead to user profile pages like `https://www.w3.org/users/6222`, that are not public)
* Added a missing `<section>` for one of the main chunks that have a `<h2>` heading

(Trailing spaces in some lines removed, too.)