### PR TITLE
Add Diego Ferreiro to Web Components F2F 2018 attendees

### DIFF
--- a/meetings/18-03-Web-components.md
+++ b/meetings/18-03-Web-components.md
@@ -26,6 +26,7 @@ Phone: +81-3-6384-9000
 * Tomek Wytrębowicz
 * Patrick Kettner
 * Justin Fagnani
+* Diego Ferreiro Val
 * please make a PR to add your name here
 
 ### hopeful


### PR DESCRIPTION
I can't make it to Japan this time, but Diego (@diervo) can represent us. /cc @justinfagnani @domenic